### PR TITLE
Add light theme

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,7 @@
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
     <title><%= htmlWebpackPlugin.options.title %></title>
   </head>
-  <body>
+  <body class="dark">
     <noscript>
       <strong>We're sorry but <%= htmlWebpackPlugin.options.title %> doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
     </noscript>

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,7 +2,17 @@
   <div class="app">
     <h1>vue-markdown-editor</h1>
     <p>A Markdown editor component for Vue that renders in place without the need for a preview pane. This is the component that powers <a href="https://github.com/voraciousdev/octo">Octo</a>.</p>
-    <MarkdownEditor v-model="markdown" class="editor" />
+    <MarkdownEditor v-model="markdown" :theme="theme" :settings="{ images: { enabled: true } }" class="editor" />
+    <div class="toggle">
+      <label>
+        <input v-model="theme" type="radio" value="light">
+        <span>light</span>
+      </label>
+      <label>
+        <input v-model="theme" type="radio" value="dark">
+        <span>dark</span>
+      </label>
+    </div>
   </div>
 </template>
 
@@ -17,7 +27,14 @@ export default {
   data() {
     return {
       markdown: '# Hello, World!',
+      theme: 'dark',
     }
+  },
+  watch: {
+    theme(value) {
+      document.body.classList.remove('dark', 'light')
+      document.body.classList.add(value)
+    },
   },
 }
 </script>
@@ -32,8 +49,6 @@ html {
 }
 
 body {
-  background-color: #111;
-  color: #aaa;
   font-family: sans-serif;
   height: 100vh;
   height: -webkit-fill-available;
@@ -43,7 +58,6 @@ body {
 }
 
 a {
-  color: #aaa;
   font-weight: bold;
 }
 
@@ -53,9 +67,35 @@ a {
   width: 100%;
 }
 
+.toggle {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+}
+
 .editor {
-  background-color: #050505;
   border-radius: 0.25em;
   padding: 1em;
+}
+
+.dark {
+  background-color: #111;
+  color: #aaa;
+}
+
+.dark a {
+  color: #aaa;
+}
+
+.dark .editor {
+  background-color: #050505;
+}
+
+.light a {
+  color: #000;
+}
+
+.light .editor {
+  background-color: #eee;
 }
 </style>

--- a/src/common/codemirror/codemirror.js
+++ b/src/common/codemirror/codemirror.js
@@ -1,13 +1,18 @@
 import CodeMirror from 'codemirror'
 import 'codemirror/mode/meta'
 
-const modes = []
+let modes = []
 let vimLoaded = false
 
 const addModeScript = (mode, options) => {
   const modeUrl = getModeUrl(mode)
+  const onerror = () => {
+    modes = modes.filter((m) => m !== mode)
 
-  addScript(modeUrl, options)
+    options.onerror()
+  }
+
+  addScript(modeUrl, { onload: options.onload, onerror })
 }
 
 const addScript = (url, { onload, onerror }) => {
@@ -55,6 +60,12 @@ export const loadMode = (fuzzyMode, options) => {
   const mode = fuzzyFindMode(fuzzyMode)
 
   if (mode && mode.mode !== 'null' && !modes.some((m) => m.mode === mode.mode)) {
+    if (mode.mode === 'vue') {
+      loadMode('html', options)
+      loadMode('css', options)
+      loadMode('js', options)
+    }
+
     modes.push(mode)
 
     // ensure CodeMirror namespace exists in the browser

--- a/src/components/MarkdownEditor.vue
+++ b/src/components/MarkdownEditor.vue
@@ -1,5 +1,5 @@
 <template>
-  <codemirror :options="options" :value="value" @input="onInput" @ready="onReady" />
+  <codemirror class="editor" :class="{ dark: (theme === 'dark'), light: (theme === 'light') }" :options="options" :value="value" @input="onInput" @ready="onReady" />
 </template>
 
 <script>
@@ -45,6 +45,10 @@ export default {
       default: () => ({
         // nothing yet
       }),
+    },
+    theme: {
+      type: String,
+      default: 'dark',
     },
     value: String,
   },
@@ -231,87 +235,116 @@ export default {
 }
 </script>
 
-<style>
-.CodeMirror.cm-s-yeti {
+<style scoped>
+.editor >>> .CodeMirror.cm-s-yeti {
   background-color: transparent !important;
 }
 
-.CodeMirror.cm-s-yeti .cm-comment {
-  color: #9e9e9e;
+.editor >>> .CodeMirror .cm-m-markdown:not(.cm-comment) {
+  font-family: sans-serif !important;
 }
 
-.CodeMirror.cm-s-yeti .cm-formatting-em, .CodeMirror.cm-s-yeti .cm-formatting-strong, .CodeMirror.cm-s-yeti .cm-formatting-strikethrough {
-  color: #444;
-}
-
-.CodeMirror.CodeMirror-focused.cm-s-yeti .CodeMirror-selected, .CodeMirror.cm-s-yeti .CodeMirror-selected {
-  background: #555;
-}
-
-.CodeMirror.cm-s-yeti.cm-fat-cursor .CodeMirror-cursor {
-  background: #557bab;
-}
-
-.CodeMirror.cm-s-yeti .cm-animate-fat-cursor {
-  background-color: #557bab;
-}
-
-.CodeMirror.cm-s-yeti .cm-m-markdown.cm-variable-2:not(.cm-comment),
-.CodeMirror.cm-s-yeti .cm-m-markdown.cm-variable-3:not(.cm-comment),
-.CodeMirror.cm-s-yeti .cm-m-markdown.cm-keyword:not(.cm-comment) {
-  color: #d1c9c0;
-}
-
-.CodeMirror.cm-s-yeti .cm-m-markdown.cm-formatting-list {
-  color: #96c0d8 !important;
-}
-
-.CodeMirror .cm-m-markdown:not(.cm-comment) {
-  font-family: 'Fira Sans', arial !important;
-}
-
-.CodeMirror {
-  color: #fff;
+.editor >>> .CodeMirror {
   min-height: 100%;
   height: auto;
 }
 
-.CodeMirror {
+.editor >>> .CodeMirror {
   position: relative;
   font-size: 1em;
   line-height: 2.25em;
 }
 
-.CodeMirror pre.CodeMirror-line,
-.CodeMirror pre.CodeMirror-line-like {
+.editor >>> .CodeMirror pre.CodeMirror-line,
+.editor >>> .CodeMirror pre.CodeMirror-line-like {
   padding: 0;
 }
 
-.CodeMirror .cm-header-1 {
+.editor >>> .CodeMirror .cm-header-1 {
   font-size: 1.6em;
 }
 
-.CodeMirror .cm-header-2 {
+.editor >>> .CodeMirror .cm-header-2 {
   font-size: 1.5em;
 }
 
-.CodeMirror .cm-header-3 {
+.editor >>> .CodeMirror .cm-header-3 {
   font-size: 1.4em;
 }
 
-.CodeMirror .cm-header-4 {
+.editor >>> .CodeMirror .cm-header-4 {
   font-size: 1.3em;
 }
 
-.CodeMirror .cm-header-5 {
+.editor >>> .CodeMirror .cm-header-5 {
   font-size: 1.2em;
 }
 
-.CodeMirror .cm-header-6 {
+.editor >>> .CodeMirror .cm-header-6 {
   font-size: 1.1em;
 }
 
-.CodeMirror-scroll {
+.editor >>> .CodeMirror-scroll {
   overflow-y: hidden !important;
+}
+
+/* dark and light themes */
+
+.editor >>> .CodeMirror.cm-s-yeti .cm-m-markdown.cm-formatting-list {
+  color: #96c0d8 !important;
+}
+
+.editor >>> .CodeMirror.cm-s-yeti .cm-comment {
+  color: #9e9e9e;
+}
+
+.light.editor >>> .CodeMirror .CodeMirror-line,
+.light.editor >>> .CodeMirror .CodeMirror-line-like {
+  color: #000;
+}
+
+.dark.editor >>> .CodeMirror.cm-s-yeti .cm-formatting-em,
+.dark.editor >>> .CodeMirror.cm-s-yeti .cm-formatting-strong,
+.dark.editor >>> .CodeMirror.cm-s-yeti .cm-formatting-strikethrough {
+  color: #444;
+}
+
+.light.editor >>> .CodeMirror.cm-s-yeti .cm-formatting-em,
+.light.editor >>> .CodeMirror.cm-s-yeti .cm-formatting-strong,
+.light.editor >>> .CodeMirror.cm-s-yeti .cm-formatting-strikethrough {
+  color: #bbb;
+}
+
+.dark.editor >>> .CodeMirror.CodeMirror-focused.cm-s-yeti .CodeMirror-selected,
+.dark.editor >>> .CodeMirror.cm-s-yeti .CodeMirror-selected {
+  background: #555;
+}
+
+.dark.editor >>> .CodeMirror.cm-s-yeti.cm-fat-cursor .CodeMirror-cursor {
+  background: #557bab;
+}
+
+.dark.editor >>> .CodeMirror.cm-s-yeti .cm-animate-fat-cursor {
+  background-color: #557bab;
+}
+
+.dark.editor >>> .CodeMirror.cm-s-yeti .cm-m-markdown.cm-variable-2:not(.cm-comment),
+.dark.editor >>> .CodeMirror.cm-s-yeti .cm-m-markdown.cm-variable-3:not(.cm-comment),
+.dark.editor >>> .CodeMirror.cm-s-yeti .cm-m-markdown.cm-keyword:not(.cm-comment) {
+  color: #d1c9c0;
+}
+
+.light.editor >>> .CodeMirror.cm-s-yeti .cm-m-markdown.cm-variable-2:not(.cm-comment),
+.light.editor >>> .CodeMirror.cm-s-yeti .cm-m-markdown.cm-variable-3:not(.cm-comment),
+.light.editor >>> .CodeMirror.cm-s-yeti .cm-m-markdown.cm-keyword:not(.cm-comment) {
+  color: #444;
+}
+
+.dark.editor >>> .CodeMirror {
+  color: #fff;
+}
+
+.light.editor >>> .caption {
+  color: #444;
 }
 </style>

--- a/src/components/MarkdownEditorImage.vue
+++ b/src/components/MarkdownEditorImage.vue
@@ -1,8 +1,8 @@
 <template>
-  <div class="container rounded d-flex align-items-center justify-content-center p-3 mw-100 mb-2">
-    <figure class="m-0">
-      <img :src="source" @load="onLoad" @error="onError" :alt="alt" class="mw-100">
-      <figcaption v-if="showCaptions && alt" class="sans-serif text-center mt-3"><small>{{ alt }}</small></figcaption>
+  <div class="container">
+    <figure class="figure">
+      <img :src="source" @load="onLoad" @error="onError" :alt="alt">
+      <figcaption v-if="showCaptions && alt" class="caption sans-serif"><small>{{ alt }}</small></figcaption>
     </figure>
   </div>
 </template>
@@ -22,10 +22,30 @@ export default {
 
 <style scoped>
 .container {
-  background-color: rgba(0, 0, 0, 0.3)
+  background-color: rgba(0, 0, 0, 0.3);
+  border-radius: 0.25rem !important;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  padding: 1rem;
+  margin-bottom: 0.5rem;
+  max-width: 100%;
 }
 
 .container img {
+  display: block;
   max-height: 20rem;
+  max-width: 100%;
+}
+
+.container .figure {
+  margin: 0;
+}
+
+.container .caption {
+  text-align: center;
+  margin-top: 1rem;
 }
 </style>


### PR DESCRIPTION
- closes #1 
- closes #2 
- closes #3

### Summary

This adds the ability for a user to specify a theme dynamically. There is a new top-level prop called `theme`, and the value can either be `light` or `dark`. The default theme is dark for backward compatibility. 

This also fixes the image layout and Vue syntax highlighting.