### PR TITLE
Support other CodeMirror themes

### DIFF
--- a/src/components/MarkdownEditor.vue
+++ b/src/components/MarkdownEditor.vue
@@ -62,6 +62,7 @@ export default {
         keyMap: 'default',
         mode: 'gfm',
         tabSize: 2,
+        theme: 'one-mixed',
       },
       editor: null,
       isInitialVimModeSet: false,
@@ -121,7 +122,7 @@ export default {
         },
         singleCursorHeightPerLine: true,
         tabSize: this.config.tabSize,
-        theme: 'one-mixed',
+        theme: this.config.theme,
       }
     },
   },


### PR DESCRIPTION
- closes #7 

### Summary

This will allow other CodeMirror themes to be used. The theme CSS will have to be loaded by the consumer of this library.